### PR TITLE
Tweak kube-at-a-glance

### DIFF
--- a/kube-at-a-glance.json
+++ b/kube-at-a-glance.json
@@ -17,7 +17,7 @@
   "gnetId": 315,
   "graphTooltip": 0,
   "id": 9,
-  "iteration": 1546265623400,
+  "iteration": 1548782743113,
   "links": [],
   "panels": [
     {
@@ -2079,6 +2079,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network I/O usage",
       "tooltip": {
@@ -2210,17 +2211,11 @@
           "intervalFactor": 1,
           "legendFormat": "Pod capacity",
           "refId": "D"
-        },
-        {
-          "expr": "count (container_last_seen{kubernetes_io_hostname=~\"^$Node$\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "Containers",
-          "refId": "E"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Pod history",
       "tooltip": {
@@ -2244,7 +2239,7 @@
           "label": "pods",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2253,7 +2248,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -2321,6 +2316,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Container error by type",
       "tooltip": {
@@ -2344,7 +2340,7 @@
           "label": "ops/min",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2436,6 +2432,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Container errors by node",
       "tooltip": {
@@ -2459,7 +2456,7 @@
           "label": "ops/min",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3262,6 +3259,7 @@
           ]
         },
         "datasource": "Prometheus",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": null,
@@ -3287,6 +3285,7 @@
           ]
         },
         "datasource": "Prometheus",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": null,
@@ -3312,6 +3311,7 @@
           ]
         },
         "datasource": "Prometheus",
+        "definition": "",
         "hide": 2,
         "includeAll": true,
         "label": null,
@@ -3362,5 +3362,5 @@
   "timezone": "browser",
   "title": "Kube at a glance",
   "uid": "mG-D07Nmk2",
-  "version": 17
+  "version": 18
 }


### PR DESCRIPTION
* Zero-base counter graphs (since they can’t go negative)
* Remove container count from pod count graph (since it doesn’t make sense relative to the pod limit, it makes the chart confusing)