### PR TITLE
Add OOMKillings to Kube at a Glance

### DIFF
--- a/kube-at-a-glance.json
+++ b/kube-at-a-glance.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": 315,
   "graphTooltip": 0,
-  "id": 9,
-  "iteration": 1546265623400,
+  "id": 11,
+  "iteration": 1549989294634,
   "links": [],
   "panels": [
     {
@@ -1928,7 +1928,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(245, 54, 54, 0.9)"
       ],
-      "datasource": "Prometheus",
+      "datasource": "-- Mixed --",
       "decimals": 0,
       "editable": true,
       "error": false,
@@ -1986,6 +1986,7 @@
       "tableColumn": "",
       "targets": [
         {
+          "datasource": "Prometheus",
           "expr": "sum(rate(kubelet_docker_operations_errors[1m]))",
           "format": "time_series",
           "instant": true,
@@ -2079,6 +2080,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network I/O usage",
       "tooltip": {
@@ -2221,6 +2223,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Pod history",
       "tooltip": {
@@ -2266,7 +2269,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "-- Mixed --",
       "decimals": 0,
       "editable": true,
       "error": false,
@@ -2309,6 +2312,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "Prometheus",
           "expr": "sum(rate(kubelet_docker_operations_errors{instance=~\"^$Node$\"}[1m])) by (operation_type)",
           "format": "time_series",
           "interval": "10s",
@@ -2317,10 +2321,38 @@
           "metric": "network",
           "refId": "A",
           "step": 10
+        },
+        {
+          "alias": "oom_killing",
+          "bucketAggs": [
+            {
+              "field": "lastTimestamp",
+              "id": "2",
+              "settings": {
+                "interval": "10s",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": "Kube-Events",
+          "hide": false,
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "reason:\"OOMKilling\" AND source.host:\"$Node$\"",
+          "refId": "B",
+          "timeField": "lastTimestamp"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Container error by type",
       "tooltip": {
@@ -2340,11 +2372,12 @@
       },
       "yaxes": [
         {
+          "decimals": 1,
           "format": "none",
           "label": "ops/min",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -2367,7 +2400,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "-- Mixed --",
       "decimals": 0,
       "editable": true,
       "error": false,
@@ -2424,6 +2457,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "Prometheus",
           "expr": "sum(rate(kubelet_docker_operations_errors{instance=~\"^$Node$\"}[1m])) by (instance)",
           "format": "time_series",
           "interval": "10s",
@@ -2432,10 +2466,49 @@
           "metric": "network",
           "refId": "A",
           "step": 10
+        },
+        {
+          "bucketAggs": [
+            {
+              "fake": true,
+              "field": "source.host.keyword",
+              "id": "3",
+              "settings": {
+                "min_doc_count": 1,
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "10"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "lastTimestamp",
+              "id": "2",
+              "settings": {
+                "interval": "10s",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": "Kube-Events",
+          "hide": false,
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "reason:\"OOMKilling\" AND source.host:\"$Node$\"",
+          "refId": "B",
+          "timeField": "lastTimestamp"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Container errors by node",
       "tooltip": {
@@ -2455,11 +2528,12 @@
       },
       "yaxes": [
         {
+          "decimals": 1,
           "format": "none",
-          "label": "ops/min",
+          "label": "ops",
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -3262,6 +3336,7 @@
           ]
         },
         "datasource": "Prometheus",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": null,
@@ -3271,6 +3346,7 @@
         "query": "label_values(kubernetes_io_hostname)",
         "refresh": 1,
         "regex": "(app-.*)-.*",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -3287,6 +3363,7 @@
           ]
         },
         "datasource": "Prometheus",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": null,
@@ -3296,6 +3373,7 @@
         "query": "label_values(kubernetes_io_hostname)",
         "refresh": 2,
         "regex": "$Class-(.*)",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -3312,6 +3390,7 @@
           ]
         },
         "datasource": "Prometheus",
+        "definition": "",
         "hide": 2,
         "includeAll": true,
         "label": null,
@@ -3321,6 +3400,7 @@
         "query": "label_values(kubernetes_io_hostname)",
         "refresh": 2,
         "regex": "($Class-$ID)",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -3361,6 +3441,6 @@
   },
   "timezone": "browser",
   "title": "Kube at a glance",
-  "uid": "mG-D07Nmk2",
-  "version": 17
+  "uid": "kube-at-a-glance",
+  "version": 2
 }


### PR DESCRIPTION
## Introduction
This PR implements the visualization of OOMKillings of any container processes - and not only the main one - on a per node basis.

## How it was implemented
Visualization is achieved by obtaining that Kubernetes Events from Elasticsearch in addition to Prometheus. Those events are inserted on Elastic by [event-exporter](https://github.com/bcdonadio/event-exporter) and the events themselves are generated by [node-problem-detector](https://github.com/kubernetes/node-problem-detector) by parsing the kernel log ring buffer on each node.

## Still to be done
Currently we still don't have a way to filter those per pod, as Grafana doesn't offer a way to do capture group extraction on queries. We're working on getting node-problem-detector to extract the pod ID and store it as a Kubernetes Event field.

## Screenshot
<img width="1590" alt="screen shot 2019-02-12 at 14 41 40" src="https://user-images.githubusercontent.com/1458878/52652385-2c709c00-2ed5-11e9-92a1-a6ea00a828eb.png">