### PR TITLE
Ephemeral storage: Detailed views per pod, container and namespace

### DIFF
--- a/kube-ephemeral-storage.json
+++ b/kube-ephemeral-storage.json
@@ -17,7 +17,7 @@
   "gnetId": 315,
   "graphTooltip": 0,
   "id": 360,
-  "iteration": 1586877371738,
+  "iteration": 1586892762767,
   "links": [],
   "panels": [
     {
@@ -45,6 +45,7 @@
       ],
       "datasource": "Prometheus",
       "decimals": 2,
+      "description": "The sum across all selected Nodes of the per-pod ephemeral storage usage reflected in the below graph. Does not include mounted volumes, even emptyDir and hostDirectory.",
       "editable": true,
       "error": false,
       "format": "percent",
@@ -220,6 +221,7 @@
       ],
       "datasource": "Prometheus",
       "decimals": 2,
+      "description": "The sum across all selected Instances (equivalent to nodes) of the total filesystem usage. Includes the per-pod ephemeral storage as reflected below, as well as any other disk usage on the node.",
       "editable": true,
       "error": false,
       "format": "percent",
@@ -682,6 +684,7 @@
       "dashes": false,
       "datasource": "Prometheus",
       "decimals": 3,
+      "description": "",
       "editable": true,
       "error": false,
       "fill": 0,
@@ -737,7 +740,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Pods Ephemeral Storage % usage ",
+      "title": "Pods Ephemeral Storage % of limit ",
       "tooltip": {
         "msResolution": true,
         "shared": true,
@@ -776,7 +779,7 @@
       }
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
@@ -785,120 +788,119 @@
         "y": 20
       },
       "id": 35,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "Prometheus",
-          "decimals": 3,
-          "description": "Shows ephemeral storage write layer (wl)  and log usage for pods.",
-          "editable": true,
-          "error": false,
-          "fill": 0,
-          "fillGradient": 0,
-          "grid": {},
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 21
-          },
-          "height": "",
-          "id": 39,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": true,
-          "targets": [
-            {
-              "expr": "sum (kubelet_container_log_filesystem_used_bytes{container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod)",
-              "format": "time_series",
-              "hide": false,
-              "interval": "10s",
-              "intervalFactor": 1,
-              "legendFormat": "log {{ pod }}",
-              "metric": "container_cpu",
-              "refId": "A",
-              "step": 10
-            },
-            {
-              "expr": "sum (container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod) - sum (kubelet_container_log_filesystem_used_bytes{container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod)",
-              "legendFormat": "wl {{ pod }}",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Detailed Pod Ephemeral Storage usage",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 2,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "decbytes",
-              "label": "",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        }
-      ],
+      "panels": [],
       "title": "Detailed Pods Ephemeral Storage usage",
       "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "decimals": 3,
+      "description": "Shows ephemeral storage write layer (wl) and log usage for pods.",
+      "editable": true,
+      "error": false,
+      "fill": 0,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "height": "",
+      "id": 39,
+      "isNew": true,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "expr": "sum (kubelet_container_log_filesystem_used_bytes{container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "10s",
+          "intervalFactor": 1,
+          "legendFormat": "log {{ pod }}",
+          "metric": "container_cpu",
+          "refId": "A",
+          "step": 10
+        },
+        {
+          "expr": "sum (container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod) - sum (kubelet_container_log_filesystem_used_bytes{container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod)",
+          "legendFormat": "wl {{ pod }}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Detailed Pod Ephemeral Storage usage",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 2,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "collapsed": true,
@@ -907,7 +909,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 28
       },
       "id": 44,
       "panels": [
@@ -1037,7 +1039,6 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": true,
           "text": "All",
           "value": "$__all"
         },
@@ -1063,7 +1064,6 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -1089,8 +1089,6 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": false,
-          "tags": [],
           "text": "nitro-demos",
           "value": "nitro-demos"
         },
@@ -1193,5 +1191,5 @@
   "timezone": "browser",
   "title": "Ephemeral Storage",
   "uid": "aeCh9Kie5o",
-  "version": 5
+  "version": 7
 }

--- a/kube-ephemeral-storage.json
+++ b/kube-ephemeral-storage.json
@@ -17,7 +17,7 @@
   "gnetId": 315,
   "graphTooltip": 0,
   "id": 360,
-  "iteration": 1586892762767,
+  "iteration": 1586902722439,
   "links": [],
   "panels": [
     {
@@ -212,91 +212,70 @@
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": true,
-      "colors": [
-        "rgba(50, 172, 45, 0.97)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(245, 54, 54, 0.9)"
-      ],
       "datasource": "Prometheus",
-      "decimals": 2,
       "description": "The sum across all selected Instances (equivalent to nodes) of the total filesystem usage. Includes the per-pod ephemeral storage as reflected below, as well as any other disk usage on the node.",
-      "editable": true,
-      "error": false,
-      "format": "percent",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": true,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
       "gridPos": {
         "h": 4,
         "w": 6,
         "x": 10,
         "y": 1
       },
-      "height": "180px",
       "id": 47,
-      "interval": null,
-      "isNew": true,
       "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "mappings": [
+              {
+                "id": 0,
+                "op": "=",
+                "text": "N/A",
+                "type": 1,
+                "value": "null"
+              }
+            ],
+            "max": 100,
+            "min": 0,
+            "nullValueMode": "connected",
+            "thresholds": [
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 65
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 90
+              }
+            ],
+            "unit": "percent"
+          },
+          "override": {},
+          "values": false
         },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "options": {},
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
+        "orientation": "horizontal",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
       },
-      "tableColumn": "",
+      "pluginVersion": "6.4.2",
       "targets": [
         {
-          "expr": "sum(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"})\n  / sum(node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"}) * 100",
+          "expr": "(sum(node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"}) - sum(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"}))\n  / sum(node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"}) * 100",
           "interval": "10s",
           "intervalFactor": 1,
           "refId": "A",
           "step": 10
         }
       ],
-      "thresholds": "65, 90",
       "title": "Instance File System usage",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
+      "type": "gauge"
     },
     {
       "cacheTimeout": null,
@@ -365,7 +344,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"})",
+          "expr": "sum(node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"}) - sum(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"})",
           "interval": "10s",
           "intervalFactor": 1,
           "refId": "A",
@@ -1191,5 +1170,5 @@
   "timezone": "browser",
   "title": "Ephemeral Storage",
   "uid": "aeCh9Kie5o",
-  "version": 7
+  "version": 9
 }

--- a/kube-ephemeral-storage.json
+++ b/kube-ephemeral-storage.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": 315,
   "graphTooltip": 0,
-  "id": 63,
-  "iteration": 1585935664193,
+  "id": 360,
+  "iteration": 1586877371738,
   "links": [],
   "panels": [
     {
@@ -29,7 +29,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 34,
+      "id": 41,
       "panels": [],
       "title": "Total usage",
       "type": "row"
@@ -109,7 +109,7 @@
         }
       ],
       "thresholds": "65, 90",
-      "title": "Cluster Ephemeral Storage usage",
+      "title": "Kube Ephemeral Storage usage",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -197,7 +197,181 @@
         }
       ],
       "thresholds": "",
-      "title": "Used",
+      "title": "Used by pods",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "Prometheus",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 10,
+        "y": 1
+      },
+      "height": "180px",
+      "id": 47,
+      "interval": null,
+      "isNew": true,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"})\n  / sum(node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"}) * 100",
+          "interval": "10s",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": "65, 90",
+      "title": "Instance File System usage",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "Prometheus",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "format": "decbytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "height": "1px",
+      "id": 45,
+      "interval": null,
+      "isNew": true,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "30%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(node_filesystem_avail_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"})",
+          "interval": "10s",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": "",
+      "title": "Instance usage",
       "type": "singlestat",
       "valueFontSize": "50%",
       "valueMaps": [
@@ -284,7 +458,94 @@
         }
       ],
       "thresholds": "",
-      "title": "Total",
+      "title": "Kube Total",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "Prometheus",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "format": "decbytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 4,
+        "x": 16,
+        "y": 3
+      },
+      "height": "1px",
+      "id": 46,
+      "interval": null,
+      "isNew": true,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "30%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(node_filesystem_size_bytes{fstype!=\"\",job=\"node-exporter\", instance=~\"$instance.+\"})",
+          "interval": "10s",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": "",
+      "title": "Instance Total",
       "type": "singlestat",
       "valueFontSize": "50%",
       "valueMaps": [
@@ -305,7 +566,7 @@
         "x": 0,
         "y": 5
       },
-      "id": 35,
+      "id": 34,
       "panels": [],
       "title": "Pods Ephemeral Storage usage",
       "type": "row"
@@ -513,6 +774,256 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 35,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "description": "Shows ephemeral storage write layer (wl)  and log usage for pods.",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "height": "",
+          "id": 39,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "expr": "sum (kubelet_container_log_filesystem_used_bytes{container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "log {{ pod }}",
+              "metric": "container_cpu",
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "expr": "sum (container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod) - sum (kubelet_container_log_filesystem_used_bytes{container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod)",
+              "legendFormat": "wl {{ pod }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Detailed Pod Ephemeral Storage usage",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Detailed Pods Ephemeral Storage usage",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 44,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 3,
+          "description": "Shows ephemeral storage write layer (wl)  and log usage for containers.",
+          "editable": true,
+          "error": false,
+          "fill": 0,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 22
+          },
+          "height": "",
+          "id": 42,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "expr": "sum (kubelet_container_log_filesystem_used_bytes{container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod,container)",
+              "format": "time_series",
+              "hide": false,
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "log {{ container }} | {{ pod }}",
+              "metric": "container_cpu",
+              "refId": "A",
+              "step": 10
+            },
+            {
+              "expr": "sum(container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod,container) - sum(kubelet_container_log_filesystem_used_bytes{container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod,container)",
+              "legendFormat": "wl {{ container }} | {{ pod }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Detailed Container Ephemeral Storage usage",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Detailed Container Ephemeral Storage Usage",
+      "type": "row"
     }
   ],
   "refresh": "10s",
@@ -526,7 +1037,7 @@
       {
         "allValue": ".+",
         "current": {
-          "tags": [],
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },
@@ -552,8 +1063,36 @@
       {
         "allValue": ".+",
         "current": {
+          "selected": false,
           "text": "All",
           "value": "$__all"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(kubelet_node_name{node=~\"$Node\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(kubelet_node_name{node=~\"$Node\"}, instance)",
+        "refresh": 1,
+        "regex": "^(.*):.*",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": false,
+          "tags": [],
+          "text": "nitro-demos",
+          "value": "nitro-demos"
         },
         "datasource": "Prometheus",
         "definition": "label_values(container_fs_usage_bytes{node=~\"$Node\"}, namespace)",
@@ -584,6 +1123,7 @@
         "name": "filter",
         "options": [
           {
+            "selected": true,
             "text": "",
             "value": ""
           }
@@ -596,7 +1136,9 @@
         "allValue": ".+",
         "current": {
           "text": "All",
-          "value": "$__all"
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "Prometheus",
         "definition": "label_values(container_fs_usage_bytes{node=~\"$Node\",namespace=~\"$namespace\", pod_name=~\".*$filter.*\"}, pod_name)",
@@ -620,7 +1162,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {
@@ -650,6 +1192,6 @@
   },
   "timezone": "browser",
   "title": "Ephemeral Storage",
-  "uid": "mG-D07Nmh2",
-  "version": 3
+  "uid": "aeCh9Kie5o",
+  "version": 5
 }

--- a/kube-quotas-namespace.json
+++ b/kube-quotas-namespace.json
@@ -1,1986 +1,1986 @@
 {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": "-- Grafana --",
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
-    },
-    "editable": true,
-    "gnetId": null,
-    "graphTooltip": 0,
-    "id": 31,
-    "iteration": 1572619450439,
-    "links": [],
-    "panels": [
+  "annotations": {
+    "list": [
       {
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 71,
-        "title": "Physical Resources Gauges (last minute)",
-        "type": "row"
-      },
-      {
-        "gridPos": {
-          "h": 5,
-          "w": 12,
-          "x": 0,
-          "y": 1
-        },
-        "id": 57,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": "typePhysical",
-        "repeatDirection": "h",
-        "scopedVars": {
-          "typePhysical": {
-            "selected": false,
-            "text": "memory",
-            "value": "memory"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.$typePhysical\"}\n)\n*100",
-            "format": "time_series",
-            "instant": true,
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: requests.$typePhysical",
-        "type": "gauge"
-      },
-      {
-        "gridPos": {
-          "h": 5,
-          "w": 12,
-          "x": 12,
-          "y": 1
-        },
-        "id": 73,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 57,
-        "scopedVars": {
-          "typePhysical": {
-            "selected": false,
-            "text": "cpu",
-            "value": "cpu"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.$typePhysical\"}\n)\n*100",
-            "format": "time_series",
-            "instant": true,
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: requests.$typePhysical",
-        "type": "gauge"
-      },
-      {
-        "gridPos": {
-          "h": 5,
-          "w": 12,
-          "x": 0,
-          "y": 6
-        },
-        "id": 72,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": "typePhysical",
-        "repeatDirection": "h",
-        "repeatIteration": 1572588027609,
-        "repeatPanelId": 45,
-        "scopedVars": {
-          "typePhysical": {
-            "selected": false,
-            "text": "memory",
-            "value": "memory"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.$typePhysical\"}\n)\n*100",
-            "format": "time_series",
-            "instant": true,
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: limits.$typePhysical",
-        "type": "gauge"
-      },
-      {
-        "gridPos": {
-          "h": 5,
-          "w": 12,
-          "x": 12,
-          "y": 6
-        },
-        "id": 74,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 72,
-        "scopedVars": {
-          "typePhysical": {
-            "selected": false,
-            "text": "cpu",
-            "value": "cpu"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.$typePhysical\"}\n)\n*100",
-            "format": "time_series",
-            "instant": true,
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: limits.$typePhysical",
-        "type": "gauge"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 11
-        },
-        "id": 5,
-        "panels": [],
-        "title": "Physical Resources",
-        "type": "row"
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "description": "Limits: straight lines\n\nRequests: dashed lines\n\nUsed: filled area",
-        "fill": 1,
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 12
-        },
-        "id": 2,
-        "legend": {
-          "alignAsTable": false,
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "rightSide": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "maxPerRow": 2,
-        "nullPointMode": "null",
-        "options": {},
-        "percentage": false,
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "repeat": null,
-        "repeatDirection": "h",
-        "seriesOverrides": [
-          {
-            "alias": "namespace request quota",
-            "color": "#8AB8FF",
-            "dashes": true,
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "namespace limit quota",
-            "color": "#1F60C4",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "pod request sum",
-            "color": "#FFA6B0",
-            "dashes": true,
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "pod limit sum",
-            "color": "#E02F44",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "actually used",
-            "color": "#56A64B",
-            "linewidth": 3
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.memory\"}\n)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "namespace request quota",
-            "refId": "A"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.memory\"}\n)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "namespace limit quota",
-            "refId": "D"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.memory\"}\n)",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "pod request sum",
-            "refId": "B"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.memory\"}\n)",
-            "format": "time_series",
-            "hide": false,
-            "instant": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "pod limit sum",
-            "refId": "E"
-          },
-          {
-            "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", container_name!=\"POD\", pod_name=~\"$pod\"}\n)",
-            "format": "time_series",
-            "hide": false,
-            "intervalFactor": 1,
-            "legendFormat": "actually used",
-            "refId": "C"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Memory ",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "decimals": 2,
-            "format": "bytes",
-            "label": "",
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "dashLength": 10,
-        "dashes": false,
-        "description": "Limits: straight lines\n\nRequests: dashed lines\n\nUsed: filled area",
-        "fill": 1,
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 12
-        },
-        "id": 11,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "maxPerRow": 2,
-        "nullPointMode": "null",
-        "options": {},
-        "percentage": false,
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "repeat": null,
-        "repeatDirection": "h",
-        "seriesOverrides": [
-          {
-            "alias": "namespace request quota",
-            "color": "#8AB8FF",
-            "dashes": true,
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "namespace limit quota",
-            "color": "#1F60C4",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "pod request sum",
-            "color": "#FFA6B0",
-            "dashes": true,
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "pod limit sum",
-            "color": "#E02F44",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "actually used",
-            "color": "#56A64B",
-            "linewidth": 3
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.cpu\"}\n)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "namespace request quota",
-            "refId": "A"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.cpu\"}\n)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "namespace limit quota",
-            "refId": "D"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.cpu\"}\n)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "pod request sum",
-            "refId": "B"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.cpu\"}\n)",
-            "format": "time_series",
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "pod limit sum",
-            "refId": "E"
-          },
-          {
-            "expr": "sum(\n  rate(\n    container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\"$pod\"}[1m]\n  )\n)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "actually used",
-            "refId": "C"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "CPU",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "decimals": 2,
-            "format": "none",
-            "label": "cores/Δt",
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": false
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 21
-        },
-        "id": 26,
-        "panels": [],
-        "title": "Virtual Resources Gauges (last minute)",
-        "type": "row"
-      },
-      {
-        "description": "",
-        "gridPos": {
-          "h": 4,
-          "w": 6,
-          "x": 0,
-          "y": 22
-        },
-        "id": 33,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": "typeVirtual",
-        "repeatDirection": "h",
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "persistentvolumeclaims",
-            "value": "persistentvolumeclaims"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "type": "gauge"
-      },
-      {
-        "description": "",
-        "gridPos": {
-          "h": 4,
-          "w": 6,
-          "x": 6,
-          "y": 22
-        },
-        "id": 75,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 33,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "pods",
-            "value": "pods"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "type": "gauge"
-      },
-      {
-        "description": "",
-        "gridPos": {
-          "h": 4,
-          "w": 6,
-          "x": 12,
-          "y": 22
-        },
-        "id": 76,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 33,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "replicationcontrollers",
-            "value": "replicationcontrollers"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "type": "gauge"
-      },
-      {
-        "description": "",
-        "gridPos": {
-          "h": 4,
-          "w": 6,
-          "x": 18,
-          "y": 22
-        },
-        "id": 77,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 33,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "services",
-            "value": "services"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "type": "gauge"
-      },
-      {
-        "description": "",
-        "gridPos": {
-          "h": 4,
-          "w": 6,
-          "x": 0,
-          "y": 26
-        },
-        "id": 78,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 33,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "configmaps",
-            "value": "configmaps"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "type": "gauge"
-      },
-      {
-        "description": "",
-        "gridPos": {
-          "h": 4,
-          "w": 6,
-          "x": 6,
-          "y": 26
-        },
-        "id": 79,
-        "links": [],
-        "options": {
-          "fieldOptions": {
-            "calcs": [
-              "last"
-            ],
-            "defaults": {
-              "decimals": 2,
-              "max": 100,
-              "min": 0,
-              "unit": "percent"
-            },
-            "mappings": [],
-            "override": {},
-            "thresholds": [
-              {
-                "color": "green",
-                "index": 0,
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "index": 1,
-                "value": 75
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "value": 90
-              }
-            ],
-            "values": false
-          },
-          "orientation": "auto",
-          "showThresholdLabels": false,
-          "showThresholdMarkers": true
-        },
-        "pluginVersion": "6.2.4",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 33,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "secrets",
-            "value": "secrets"
-          }
-        },
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "type": "gauge"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 30
-        },
-        "id": 15,
-        "panels": [],
-        "repeat": null,
-        "title": "Virtual Resources",
-        "type": "row"
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "cacheTimeout": null,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "Prometheus",
-        "fill": 1,
-        "gridPos": {
-          "h": 5,
-          "w": 6,
-          "x": 0,
-          "y": 31
-        },
-        "id": 19,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {},
-        "percentage": false,
-        "pluginVersion": "6.2.4",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "repeat": "typeVirtual",
-        "repeatDirection": "h",
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "persistentvolumeclaims",
-            "value": "persistentvolumeclaims"
-          }
-        },
-        "seriesOverrides": [
-          {
-            "alias": "namespace quota",
-            "color": "#E0B400",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "actually used",
-            "color": "#56A64B",
-            "linewidth": 3
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "namespace quota",
-            "refId": "B"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "interval": "1m",
-            "intervalFactor": 1,
-            "legendFormat": "actually used",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "cacheTimeout": null,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "Prometheus",
-        "fill": 1,
-        "gridPos": {
-          "h": 5,
-          "w": 6,
-          "x": 6,
-          "y": 31
-        },
-        "id": 80,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {},
-        "percentage": false,
-        "pluginVersion": "6.2.4",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 19,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "pods",
-            "value": "pods"
-          }
-        },
-        "seriesOverrides": [
-          {
-            "alias": "namespace quota",
-            "color": "#E0B400",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "actually used",
-            "color": "#56A64B",
-            "linewidth": 3
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "namespace quota",
-            "refId": "B"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "interval": "1m",
-            "intervalFactor": 1,
-            "legendFormat": "actually used",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "cacheTimeout": null,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "Prometheus",
-        "fill": 1,
-        "gridPos": {
-          "h": 5,
-          "w": 6,
-          "x": 12,
-          "y": 31
-        },
-        "id": 81,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {},
-        "percentage": false,
-        "pluginVersion": "6.2.4",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 19,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "replicationcontrollers",
-            "value": "replicationcontrollers"
-          }
-        },
-        "seriesOverrides": [
-          {
-            "alias": "namespace quota",
-            "color": "#E0B400",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "actually used",
-            "color": "#56A64B",
-            "linewidth": 3
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "namespace quota",
-            "refId": "B"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "interval": "1m",
-            "intervalFactor": 1,
-            "legendFormat": "actually used",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "cacheTimeout": null,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "Prometheus",
-        "fill": 1,
-        "gridPos": {
-          "h": 5,
-          "w": 6,
-          "x": 18,
-          "y": 31
-        },
-        "id": 82,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {},
-        "percentage": false,
-        "pluginVersion": "6.2.4",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 19,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "services",
-            "value": "services"
-          }
-        },
-        "seriesOverrides": [
-          {
-            "alias": "namespace quota",
-            "color": "#E0B400",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "actually used",
-            "color": "#56A64B",
-            "linewidth": 3
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "namespace quota",
-            "refId": "B"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "interval": "1m",
-            "intervalFactor": 1,
-            "legendFormat": "actually used",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "cacheTimeout": null,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "Prometheus",
-        "fill": 1,
-        "gridPos": {
-          "h": 5,
-          "w": 6,
-          "x": 0,
-          "y": 36
-        },
-        "id": 83,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {},
-        "percentage": false,
-        "pluginVersion": "6.2.4",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 19,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "configmaps",
-            "value": "configmaps"
-          }
-        },
-        "seriesOverrides": [
-          {
-            "alias": "namespace quota",
-            "color": "#E0B400",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "actually used",
-            "color": "#56A64B",
-            "linewidth": 3
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "namespace quota",
-            "refId": "B"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "interval": "1m",
-            "intervalFactor": 1,
-            "legendFormat": "actually used",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "cacheTimeout": null,
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "Prometheus",
-        "fill": 1,
-        "gridPos": {
-          "h": 5,
-          "w": 6,
-          "x": 6,
-          "y": 36
-        },
-        "id": 84,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": true,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 1,
-        "links": [],
-        "nullPointMode": "null",
-        "options": {},
-        "percentage": false,
-        "pluginVersion": "6.2.4",
-        "pointradius": 2,
-        "points": false,
-        "renderer": "flot",
-        "repeat": null,
-        "repeatDirection": "h",
-        "repeatIteration": 1572619450439,
-        "repeatPanelId": 19,
-        "scopedVars": {
-          "typeVirtual": {
-            "selected": false,
-            "text": "secrets",
-            "value": "secrets"
-          }
-        },
-        "seriesOverrides": [
-          {
-            "alias": "namespace quota",
-            "color": "#E0B400",
-            "fill": 0,
-            "linewidth": 2
-          },
-          {
-            "alias": "actually used",
-            "color": "#56A64B",
-            "linewidth": 3
-          }
-        ],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "namespace quota",
-            "refId": "B"
-          },
-          {
-            "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
-            "format": "time_series",
-            "interval": "1m",
-            "intervalFactor": 1,
-            "legendFormat": "actually used",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Quota: $typeVirtual",
-        "tooltip": {
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": "0",
-            "show": true
-          },
-          {
-            "format": "short",
-            "label": null,
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-    ],
-    "schemaVersion": 18,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": [
-        {
-          "allValue": null,
-          "current": {
-            "text": "All",
-            "value": "$__all"
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 31,
+  "iteration": 1572619450439,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 71,
+      "title": "Physical Resources Gauges (last minute)",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 57,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
           },
-          "datasource": "Prometheus",
-          "definition": "label_values(kube_resourcequota, resource)",
-          "hide": 2,
-          "includeAll": true,
-          "label": "Type Virtual",
-          "multi": false,
-          "name": "typeVirtual",
-          "options": [],
-          "query": "label_values(kube_resourcequota, resource)",
-          "refresh": 2,
-          "regex": "^(?!.*\\.).*$",
-          "skipUrlSync": false,
-          "sort": 0,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
-        },
-        {
-          "allValue": null,
-          "current": {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          "hide": 2,
-          "includeAll": true,
-          "label": "Type Physical",
-          "multi": false,
-          "name": "typePhysical",
-          "options": [
+          "mappings": [],
+          "override": {},
+          "thresholds": [
             {
-              "selected": true,
-              "text": "All",
-              "value": "$__all"
+              "color": "green",
+              "index": 0,
+              "value": null
             },
             {
-              "selected": false,
-              "text": "memory",
-              "value": "memory"
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
             },
             {
-              "selected": false,
-              "text": "cpu",
-              "value": "cpu"
+              "color": "red",
+              "index": 2,
+              "value": 90
             }
           ],
-          "query": "memory, cpu",
-          "skipUrlSync": false,
-          "type": "custom"
+          "values": false
         },
-        {
-          "allValue": null,
-          "current": {
-            "selected": true,
-            "text": "All",
-            "value": "$__all"
-          },
-          "hide": 2,
-          "includeAll": true,
-          "label": "Nature",
-          "multi": false,
-          "name": "nature",
-          "options": [
-            {
-              "selected": true,
-              "text": "All",
-              "value": "$__all"
-            },
-            {
-              "selected": false,
-              "text": "requests",
-              "value": "requests"
-            },
-            {
-              "selected": false,
-              "text": "limits",
-              "value": "limits"
-            }
-          ],
-          "query": "requests,limits",
-          "skipUrlSync": false,
-          "type": "custom"
-        },
-        {
-          "allValue": null,
-          "current": {
-            "text": "nitro-demos",
-            "value": "nitro-demos"
-          },
-          "datasource": "Prometheus",
-          "definition": "label_values(kube_pod_info, namespace)",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Namespace",
-          "multi": true,
-          "name": "namespace",
-          "options": [],
-          "query": "label_values(kube_pod_info, namespace)",
-          "refresh": 2,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 1,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
-        },
-        {
-          "allValue": ".+",
-          "current": {
-            "text": "All",
-            "value": "$__all"
-          },
-          "datasource": "Prometheus",
-          "definition": "query_result(kube_pod_status_phase{phase=\"Running\",namespace=~\"$namespace\"}==1)",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Pod",
-          "multi": true,
-          "name": "pod",
-          "options": [],
-          "query": "query_result(kube_pod_status_phase{phase=\"Running\",namespace=~\"$namespace\"}==1)",
-          "refresh": 2,
-          "regex": "/pod=\\\"([a-zA-Z0-9\\-\\_]+)\\\"/",
-          "skipUrlSync": false,
-          "sort": 0,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": "typePhysical",
+      "repeatDirection": "h",
+      "scopedVars": {
+        "typePhysical": {
+          "selected": false,
+          "text": "memory",
+          "value": "memory"
         }
-      ]
-    },
-    "time": {
-      "from": "now-6h",
-      "to": "now"
-    },
-    "timepicker": {
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.$typePhysical\"}\n)\n*100",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
       ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ]
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: requests.$typePhysical",
+      "type": "gauge"
     },
-    "timezone": "",
-    "title": "Kube Quotas (Namespace)",
-    "uid": "6MFyi50Zz",
-    "version": 55
+    {
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 73,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "mappings": [],
+          "override": {},
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 90
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 57,
+      "scopedVars": {
+        "typePhysical": {
+          "selected": false,
+          "text": "cpu",
+          "value": "cpu"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.$typePhysical\"}\n)\n*100",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: requests.$typePhysical",
+      "type": "gauge"
+    },
+    {
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 72,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "mappings": [],
+          "override": {},
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 90
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": "typePhysical",
+      "repeatDirection": "h",
+      "repeatIteration": 1572588027609,
+      "repeatPanelId": 45,
+      "scopedVars": {
+        "typePhysical": {
+          "selected": false,
+          "text": "memory",
+          "value": "memory"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.$typePhysical\"}\n)\n*100",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: limits.$typePhysical",
+      "type": "gauge"
+    },
+    {
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 74,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "mappings": [],
+          "override": {},
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 90
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 72,
+      "scopedVars": {
+        "typePhysical": {
+          "selected": false,
+          "text": "cpu",
+          "value": "cpu"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.$typePhysical\"}\n)\n*100",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: limits.$typePhysical",
+      "type": "gauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 5,
+      "panels": [],
+      "title": "Physical Resources",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Limits: straight lines\n\nRequests: dashed lines\n\nUsed: filled area",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 2,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxPerRow": 2,
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "seriesOverrides": [
+        {
+          "alias": "namespace request quota",
+          "color": "#8AB8FF",
+          "dashes": true,
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "namespace limit quota",
+          "color": "#1F60C4",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "pod request sum",
+          "color": "#FFA6B0",
+          "dashes": true,
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "pod limit sum",
+          "color": "#E02F44",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "actually used",
+          "color": "#56A64B",
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.memory\"}\n)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "namespace request quota",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.memory\"}\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "namespace limit quota",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.memory\"}\n)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "pod request sum",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.memory\"}\n)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "pod limit sum",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", container_name!=\"POD\", pod_name=~\"$pod\"}\n)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "actually used",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory ",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "bytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Limits: straight lines\n\nRequests: dashed lines\n\nUsed: filled area",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxPerRow": 2,
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "seriesOverrides": [
+        {
+          "alias": "namespace request quota",
+          "color": "#8AB8FF",
+          "dashes": true,
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "namespace limit quota",
+          "color": "#1F60C4",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "pod request sum",
+          "color": "#FFA6B0",
+          "dashes": true,
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "pod limit sum",
+          "color": "#E02F44",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "actually used",
+          "color": "#56A64B",
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.cpu\"}\n)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "namespace request quota",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.cpu\"}\n)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "namespace limit quota",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.cpu\"}\n)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "pod request sum",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.cpu\"}\n)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "pod limit sum",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(\n  rate(\n    container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\"$pod\"}[1m]\n  )\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "actually used",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "none",
+          "label": "cores/Δt",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Virtual Resources Gauges (last minute)",
+      "type": "row"
+    },
+    {
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 22
+      },
+      "id": 33,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "mappings": [],
+          "override": {},
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 90
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": "typeVirtual",
+      "repeatDirection": "h",
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "persistentvolumeclaims",
+          "value": "persistentvolumeclaims"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "type": "gauge"
+    },
+    {
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 22
+      },
+      "id": 75,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "mappings": [],
+          "override": {},
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 90
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 33,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "pods",
+          "value": "pods"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "type": "gauge"
+    },
+    {
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 22
+      },
+      "id": 76,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "mappings": [],
+          "override": {},
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 90
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 33,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "replicationcontrollers",
+          "value": "replicationcontrollers"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "type": "gauge"
+    },
+    {
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 22
+      },
+      "id": 77,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "mappings": [],
+          "override": {},
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 90
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 33,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "services",
+          "value": "services"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "type": "gauge"
+    },
+    {
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 26
+      },
+      "id": 78,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "mappings": [],
+          "override": {},
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 90
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 33,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "configmaps",
+          "value": "configmaps"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "type": "gauge"
+    },
+    {
+      "description": "",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 26
+      },
+      "id": 79,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "max": 100,
+            "min": 0,
+            "unit": "percent"
+          },
+          "mappings": [],
+          "override": {},
+          "thresholds": [
+            {
+              "color": "green",
+              "index": 0,
+              "value": null
+            },
+            {
+              "color": "#EAB839",
+              "index": 1,
+              "value": 75
+            },
+            {
+              "color": "red",
+              "index": 2,
+              "value": 90
+            }
+          ],
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.2.4",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 33,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "secrets",
+          "value": "secrets"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)\n*100",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "type": "gauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 15,
+      "panels": [],
+      "repeat": null,
+      "title": "Virtual Resources",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 31
+      },
+      "id": 19,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pluginVersion": "6.2.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": "typeVirtual",
+      "repeatDirection": "h",
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "persistentvolumeclaims",
+          "value": "persistentvolumeclaims"
+        }
+      },
+      "seriesOverrides": [
+        {
+          "alias": "namespace quota",
+          "color": "#E0B400",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "actually used",
+          "color": "#56A64B",
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "namespace quota",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "actually used",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 31
+      },
+      "id": 80,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pluginVersion": "6.2.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 19,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "pods",
+          "value": "pods"
+        }
+      },
+      "seriesOverrides": [
+        {
+          "alias": "namespace quota",
+          "color": "#E0B400",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "actually used",
+          "color": "#56A64B",
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "namespace quota",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "actually used",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 31
+      },
+      "id": 81,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pluginVersion": "6.2.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 19,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "replicationcontrollers",
+          "value": "replicationcontrollers"
+        }
+      },
+      "seriesOverrides": [
+        {
+          "alias": "namespace quota",
+          "color": "#E0B400",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "actually used",
+          "color": "#56A64B",
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "namespace quota",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "actually used",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 31
+      },
+      "id": 82,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pluginVersion": "6.2.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 19,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "services",
+          "value": "services"
+        }
+      },
+      "seriesOverrides": [
+        {
+          "alias": "namespace quota",
+          "color": "#E0B400",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "actually used",
+          "color": "#56A64B",
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "namespace quota",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "actually used",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 36
+      },
+      "id": 83,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pluginVersion": "6.2.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 19,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "configmaps",
+          "value": "configmaps"
+        }
+      },
+      "seriesOverrides": [
+        {
+          "alias": "namespace quota",
+          "color": "#E0B400",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "actually used",
+          "color": "#56A64B",
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "namespace quota",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "actually used",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 36
+      },
+      "id": 84,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pluginVersion": "6.2.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1572619450439,
+      "repeatPanelId": 19,
+      "scopedVars": {
+        "typeVirtual": {
+          "selected": false,
+          "text": "secrets",
+          "value": "secrets"
+        }
+      },
+      "seriesOverrides": [
+        {
+          "alias": "namespace quota",
+          "color": "#E0B400",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "actually used",
+          "color": "#56A64B",
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "namespace quota",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"$typeVirtual\"}\n)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "actually used",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Quota: $typeVirtual",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(kube_resourcequota, resource)",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Type Virtual",
+        "multi": false,
+        "name": "typeVirtual",
+        "options": [],
+        "query": "label_values(kube_resourcequota, resource)",
+        "refresh": 2,
+        "regex": "^(?!.*\\.).*$",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 2,
+        "includeAll": true,
+        "label": "Type Physical",
+        "multi": false,
+        "name": "typePhysical",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "memory",
+            "value": "memory"
+          },
+          {
+            "selected": false,
+            "text": "cpu",
+            "value": "cpu"
+          }
+        ],
+        "query": "memory, cpu",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 2,
+        "includeAll": true,
+        "label": "Nature",
+        "multi": false,
+        "name": "nature",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "requests",
+            "value": "requests"
+          },
+          {
+            "selected": false,
+            "text": "limits",
+            "value": "limits"
+          }
+        ],
+        "query": "requests,limits",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "nitro-demos",
+          "value": "nitro-demos"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(kube_pod_info, namespace)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Prometheus",
+        "definition": "query_result(kube_pod_status_phase{phase=\"Running\",namespace=~\"$namespace\"}==1)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": "query_result(kube_pod_status_phase{phase=\"Running\",namespace=~\"$namespace\"}==1)",
+        "refresh": 2,
+        "regex": "/pod=\\\"([a-zA-Z0-9\\-\\_]+)\\\"/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Kube Quotas (Namespace)",
+  "uid": "6MFyi50Zz",
+  "version": 55
 }

--- a/kube-quotas-namespace.json
+++ b/kube-quotas-namespace.json
@@ -15,11 +15,12 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 31,
-  "iteration": 1572619450439,
+  "id": 361,
+  "iteration": 1586898239537,
   "links": [],
   "panels": [
     {
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -31,9 +32,10 @@
       "type": "row"
     },
     {
+      "datasource": null,
       "gridPos": {
         "h": 5,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 1
       },
@@ -46,36 +48,33 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": "typePhysical",
       "repeatDirection": "h",
       "scopedVars": {
@@ -100,13 +99,14 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "gridPos": {
         "h": 5,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 1
       },
-      "id": 73,
+      "id": 86,
       "links": [],
       "options": {
         "fieldOptions": {
@@ -115,39 +115,36 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 57,
       "scopedVars": {
         "typePhysical": {
@@ -171,9 +168,79 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "gridPos": {
         "h": 5,
-        "w": 12,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 87,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "mappings": [],
+            "max": 100,
+            "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
+            "unit": "percent"
+          },
+          "override": {},
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.4.2",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1586898239537,
+      "repeatPanelId": 57,
+      "scopedVars": {
+        "typePhysical": {
+          "selected": false,
+          "text": "ephemeral-storage",
+          "value": "ephemeral-storage"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.$typePhysical\"}\n)\n*100",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: requests.$typePhysical",
+      "type": "gauge"
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
         "x": 0,
         "y": 6
       },
@@ -186,36 +253,33 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": "typePhysical",
       "repeatDirection": "h",
       "repeatIteration": 1572588027609,
@@ -242,13 +306,14 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "gridPos": {
         "h": 5,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 6
       },
-      "id": 74,
+      "id": 88,
       "links": [],
       "options": {
         "fieldOptions": {
@@ -257,39 +322,36 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 72,
       "scopedVars": {
         "typePhysical": {
@@ -313,7 +375,77 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 89,
+      "links": [],
+      "options": {
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 2,
+            "mappings": [],
+            "max": 100,
+            "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
+            "unit": "percent"
+          },
+          "override": {},
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.4.2",
+      "repeat": null,
+      "repeatDirection": "h",
+      "repeatIteration": 1586898239537,
+      "repeatPanelId": 72,
+      "scopedVars": {
+        "typePhysical": {
+          "selected": false,
+          "text": "ephemeral-storage",
+          "value": "ephemeral-storage"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.$typePhysical\"}\n)\n/\nsum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.$typePhysical\"}\n)\n*100",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Quota: limits.$typePhysical",
+      "type": "gauge"
+    },
+    {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -330,11 +462,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Limits: straight lines\n\nRequests: dashed lines\n\nUsed: filled area",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 12
       },
@@ -355,7 +489,9 @@
       "links": [],
       "maxPerRow": 2,
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -415,7 +551,7 @@
           "refId": "D"
         },
         {
-          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.memory\"}\n)",
+          "expr": "sum( \n    kube_pod_container_resource_requests{namespace=~\"$namespace\",resource=\"memory\"}\n)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -424,14 +560,9 @@
           "refId": "B"
         },
         {
-          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.memory\"}\n)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
+          "expr": "sum( \n    kube_pod_container_resource_limits{namespace=~\"$namespace\",resource=\"memory\"}\n)",
           "legendFormat": "pod limit sum",
-          "refId": "E"
+          "refId": "F"
         },
         {
           "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", container_name!=\"POD\", pod_name=~\"$pod\"}\n)",
@@ -489,12 +620,14 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Limits: straight lines\n\nRequests: dashed lines\n\nUsed: filled area",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 12
       },
       "id": 11,
@@ -512,7 +645,9 @@
       "links": [],
       "maxPerRow": 2,
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -573,7 +708,7 @@
           "refId": "D"
         },
         {
-          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.cpu\"}\n)",
+          "expr": "sum(\n    kube_pod_container_resource_requests{namespace=~\"$namespace\",resource=\"cpu\"}\n)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -581,12 +716,9 @@
           "refId": "B"
         },
         {
-          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.cpu\"}\n)",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 1,
+          "expr": "sum(\n    kube_pod_container_resource_limits{namespace=~\"$namespace\",resource=\"cpu\"}\n)",
           "legendFormat": "pod limit sum",
-          "refId": "E"
+          "refId": "F"
         },
         {
           "expr": "sum(\n  rate(\n    container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\"$pod\"}[1m]\n  )\n)",
@@ -639,7 +771,160 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Limits: straight lines\n\nRequests: dashed lines\n\nUsed: filled area",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "id": 85,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxPerRow": 2,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "seriesOverrides": [
+        {
+          "alias": "namespace request quota",
+          "color": "#8AB8FF",
+          "dashes": true,
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "namespace limit quota",
+          "color": "#1F60C4",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "pod request sum",
+          "color": "#FFA6B0",
+          "dashes": true,
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "pod limit sum",
+          "color": "#E02F44",
+          "fill": 0,
+          "linewidth": 2
+        },
+        {
+          "alias": "actually used",
+          "color": "#56A64B",
+          "linewidth": 3
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"requests.ephemeral-storage\"}\n)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "namespace request quota",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"hard\",resource=\"limits.ephemeral-storage\"}\n)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "namespace limit quota",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(\n   kube_pod_container_resource_requests{namespace=~\"$namespace\",pod=~\"$pod\",resource=\"ephemeral_storage\"}\n)",
+          "hide": false,
+          "legendFormat": "pod request sum",
+          "refId": "G"
+        },
+        {
+          "expr": "sum(\n   kube_pod_container_resource_limits{namespace=~\"$namespace\",pod=~\"$pod\",resource=\"ephemeral_storage\"}\n)",
+          "legendFormat": "pod limit sum",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(\n  container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",namespace=~\"$namespace\",pod=~\"$pod\"}\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "actually used",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Ephemeral Storage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "decbytes",
+          "label": "ephemeral storage/Δt",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -652,6 +937,7 @@
       "type": "row"
     },
     {
+      "datasource": null,
       "description": "",
       "gridPos": {
         "h": 4,
@@ -668,36 +954,33 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": "typeVirtual",
       "repeatDirection": "h",
       "scopedVars": {
@@ -721,6 +1004,7 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "description": "",
       "gridPos": {
         "h": 4,
@@ -728,7 +1012,7 @@
         "x": 6,
         "y": 22
       },
-      "id": 75,
+      "id": 90,
       "links": [],
       "options": {
         "fieldOptions": {
@@ -737,39 +1021,36 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -792,6 +1073,7 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "description": "",
       "gridPos": {
         "h": 4,
@@ -799,7 +1081,7 @@
         "x": 12,
         "y": 22
       },
-      "id": 76,
+      "id": 91,
       "links": [],
       "options": {
         "fieldOptions": {
@@ -808,39 +1090,36 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -863,6 +1142,7 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "description": "",
       "gridPos": {
         "h": 4,
@@ -870,7 +1150,7 @@
         "x": 18,
         "y": 22
       },
-      "id": 77,
+      "id": 92,
       "links": [],
       "options": {
         "fieldOptions": {
@@ -879,39 +1159,36 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -934,6 +1211,7 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "description": "",
       "gridPos": {
         "h": 4,
@@ -941,7 +1219,7 @@
         "x": 0,
         "y": 26
       },
-      "id": 78,
+      "id": 93,
       "links": [],
       "options": {
         "fieldOptions": {
@@ -950,39 +1228,36 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -1005,6 +1280,7 @@
       "type": "gauge"
     },
     {
+      "datasource": null,
       "description": "",
       "gridPos": {
         "h": 4,
@@ -1012,7 +1288,7 @@
         "x": 6,
         "y": 26
       },
-      "id": 79,
+      "id": 94,
       "links": [],
       "options": {
         "fieldOptions": {
@@ -1021,39 +1297,36 @@
           ],
           "defaults": {
             "decimals": 2,
+            "mappings": [],
             "max": 100,
             "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ],
             "unit": "percent"
           },
-          "mappings": [],
           "override": {},
-          "thresholds": [
-            {
-              "color": "green",
-              "index": 0,
-              "value": null
-            },
-            {
-              "color": "#EAB839",
-              "index": 1,
-              "value": 75
-            },
-            {
-              "color": "red",
-              "index": 2,
-              "value": 90
-            }
-          ],
           "values": false
         },
         "orientation": "auto",
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "6.2.4",
+      "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -1077,6 +1350,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1097,6 +1371,7 @@
       "dashes": false,
       "datasource": "Prometheus",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
@@ -1117,7 +1392,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pluginVersion": "6.2.4",
       "pointradius": 2,
@@ -1214,13 +1491,14 @@
       "dashes": false,
       "datasource": "Prometheus",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 6,
         "y": 31
       },
-      "id": 80,
+      "id": 95,
       "legend": {
         "avg": false,
         "current": false,
@@ -1234,7 +1512,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pluginVersion": "6.2.4",
       "pointradius": 2,
@@ -1242,7 +1522,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -1333,13 +1613,14 @@
       "dashes": false,
       "datasource": "Prometheus",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 12,
         "y": 31
       },
-      "id": 81,
+      "id": 96,
       "legend": {
         "avg": false,
         "current": false,
@@ -1353,7 +1634,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pluginVersion": "6.2.4",
       "pointradius": 2,
@@ -1361,7 +1644,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -1452,13 +1735,14 @@
       "dashes": false,
       "datasource": "Prometheus",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 18,
         "y": 31
       },
-      "id": 82,
+      "id": 97,
       "legend": {
         "avg": false,
         "current": false,
@@ -1472,7 +1756,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pluginVersion": "6.2.4",
       "pointradius": 2,
@@ -1480,7 +1766,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -1571,13 +1857,14 @@
       "dashes": false,
       "datasource": "Prometheus",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 0,
         "y": 36
       },
-      "id": 83,
+      "id": 98,
       "legend": {
         "avg": false,
         "current": false,
@@ -1591,7 +1878,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pluginVersion": "6.2.4",
       "pointradius": 2,
@@ -1599,7 +1888,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -1690,13 +1979,14 @@
       "dashes": false,
       "datasource": "Prometheus",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 6,
         "y": 36
       },
-      "id": 84,
+      "id": 99,
       "legend": {
         "avg": false,
         "current": false,
@@ -1710,7 +2000,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pluginVersion": "6.2.4",
       "pointradius": 2,
@@ -1718,7 +2010,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1572619450439,
+      "repeatIteration": 1586898239537,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -1802,7 +2094,8 @@
       }
     }
   ],
-  "schemaVersion": 18,
+  "refresh": false,
+  "schemaVersion": 20,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1859,9 +2152,14 @@
             "selected": false,
             "text": "cpu",
             "value": "cpu"
+          },
+          {
+            "selected": false,
+            "text": "ephemeral-storage",
+            "value": "ephemeral-storage"
           }
         ],
-        "query": "memory, cpu",
+        "query": "memory, cpu,ephemeral-storage",
         "skipUrlSync": false,
         "type": "custom"
       },
@@ -1981,6 +2279,6 @@
   },
   "timezone": "",
   "title": "Kube Quotas (Namespace)",
-  "uid": "6MFyi50Zz",
-  "version": 55
+  "uid": "6MFyi50Zzw3",
+  "version": 7
 }

--- a/kube-quotas-namespace.json
+++ b/kube-quotas-namespace.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 361,
-  "iteration": 1586898239537,
+  "iteration": 1587073689381,
   "links": [],
   "panels": [
     {
@@ -144,7 +144,7 @@
       "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 57,
       "scopedVars": {
         "typePhysical": {
@@ -213,7 +213,7 @@
       "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 57,
       "scopedVars": {
         "typePhysical": {
@@ -351,7 +351,7 @@
       "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 72,
       "scopedVars": {
         "typePhysical": {
@@ -420,7 +420,7 @@
       "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 72,
       "scopedVars": {
         "typePhysical": {
@@ -551,7 +551,7 @@
           "refId": "D"
         },
         {
-          "expr": "sum( \n    kube_pod_container_resource_requests{namespace=~\"$namespace\",resource=\"memory\"}\n)",
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.memory\"}\n)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -560,7 +560,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum( \n    kube_pod_container_resource_limits{namespace=~\"$namespace\",resource=\"memory\"}\n)",
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.memory\"}\n)",
           "legendFormat": "pod limit sum",
           "refId": "F"
         },
@@ -708,7 +708,7 @@
           "refId": "D"
         },
         {
-          "expr": "sum(\n    kube_pod_container_resource_requests{namespace=~\"$namespace\",resource=\"cpu\"}\n)",
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.cpu\"}\n)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -716,7 +716,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(\n    kube_pod_container_resource_limits{namespace=~\"$namespace\",resource=\"cpu\"}\n)",
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.cpu\"}\n)",
           "legendFormat": "pod limit sum",
           "refId": "F"
         },
@@ -862,13 +862,13 @@
           "refId": "D"
         },
         {
-          "expr": "sum(\n   kube_pod_container_resource_requests{namespace=~\"$namespace\",pod=~\"$pod\",resource=\"ephemeral_storage\"}\n)",
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"requests.ephemeral-storage\"}\n)",
           "hide": false,
           "legendFormat": "pod request sum",
           "refId": "G"
         },
         {
-          "expr": "sum(\n   kube_pod_container_resource_limits{namespace=~\"$namespace\",pod=~\"$pod\",resource=\"ephemeral_storage\"}\n)",
+          "expr": "sum(\n    kube_resourcequota{namespace=~\"$namespace\",type=\"used\",resource=\"limits.ephemeral-storage\"}\n)",
           "legendFormat": "pod limit sum",
           "refId": "F"
         },
@@ -1050,7 +1050,7 @@
       "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -1119,7 +1119,7 @@
       "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -1188,7 +1188,7 @@
       "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -1257,7 +1257,7 @@
       "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -1326,7 +1326,7 @@
       "pluginVersion": "6.4.2",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 33,
       "scopedVars": {
         "typeVirtual": {
@@ -1522,7 +1522,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -1644,7 +1644,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -1766,7 +1766,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -1888,7 +1888,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -2010,7 +2010,7 @@
       "renderer": "flot",
       "repeat": null,
       "repeatDirection": "h",
-      "repeatIteration": 1586898239537,
+      "repeatIteration": 1587073689381,
       "repeatPanelId": 19,
       "scopedVars": {
         "typeVirtual": {
@@ -2225,7 +2225,9 @@
         "allValue": ".+",
         "current": {
           "text": "All",
-          "value": "$__all"
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "Prometheus",
         "definition": "query_result(kube_pod_status_phase{phase=\"Running\",namespace=~\"$namespace\"}==1)",
@@ -2280,5 +2282,5 @@
   "timezone": "",
   "title": "Kube Quotas (Namespace)",
   "uid": "6MFyi50Zzw3",
-  "version": 7
+  "version": 8
 }


### PR DESCRIPTION
## What does this PR do?
### Ephemeral storage Dashboard
* Add detailed view per pod and container.
* Add better info about instances file system usage. The kube usage isn't all there is in the instance file system, and if you only look to that it could mislead you to bad assumptions. 

<img width="1615" alt="Screen Shot 2020-04-14 at 12 23 15 PM" src="https://user-images.githubusercontent.com/17147375/79242534-d71e7a80-7e4a-11ea-9a10-e148404a6bc6.png">

### Kube resource quota (namespace)
* Add ephemeral storage view.

<img width="1601" alt="Screen Shot 2020-04-14 at 6 08 46 PM" src="https://user-images.githubusercontent.com/17147375/79274571-24b2db80-7e7b-11ea-9de3-ba314ff41ff7.png">
