### PR TITLE
pod label was updated by prometheus

### DIFF
--- a/container-health.json
+++ b/container-health.json
@@ -1002,11 +1002,11 @@
         "steppedLine": true,
         "targets": [
           {
-            "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (pod_name)",
+            "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (pod)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
-            "legendFormat": "{{ pod_name }}",
+            "legendFormat": "{{ pod }}",
             "metric": "container_cpu",
             "refId": "A",
             "step": 10
@@ -1232,18 +1232,18 @@
         "steppedLine": true,
         "targets": [
           {
-            "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",container_name!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (container_name, pod_name)",
+            "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (container, pod)",
             "format": "time_series",
             "hide": false,
             "interval": "10s",
             "intervalFactor": 1,
-            "legendFormat": "pod: {{ pod_name }} | {{ container_name }}",
+            "legendFormat": "pod: {{ pod }} | {{ container }}",
             "metric": "container_cpu",
             "refId": "A",
             "step": 10
           },
           {
-            "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name!~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (node, name, image)",
+            "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name!~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (node, name, image)",
             "format": "time_series",
             "hide": false,
             "interval": "10s",
@@ -1254,7 +1254,7 @@
             "step": 10
           },
           {
-            "expr": "sum (rate (container_cpu_usage_seconds_total{rkt_container_name!=\"\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (node, rkt_container_name)",
+            "expr": "sum (rate (container_cpu_usage_seconds_total{rkt_container_name!=\"\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (node, rkt_container_name)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
@@ -1367,7 +1367,7 @@
         "steppedLine": true,
         "targets": [
           {
-            "expr": "sum (rate (container_cpu_usage_seconds_total{id!=\"/\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (id)",
+            "expr": "sum (rate (container_cpu_usage_seconds_total{id!=\"/\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (id)",
             "format": "time_series",
             "hide": false,
             "interval": "10s",
@@ -1481,11 +1481,11 @@
         "steppedLine": true,
         "targets": [
           {
-            "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}) by (pod_name)",
+            "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
-            "legendFormat": "{{ pod_name }}",
+            "legendFormat": "{{ pod }}",
             "metric": "container_memory_usage:sort_desc",
             "refId": "A",
             "step": 10
@@ -1707,17 +1707,17 @@
         "steppedLine": true,
         "targets": [
           {
-            "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",container_name!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}) by (container_name, pod_name)",
+            "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (container, pod)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
-            "legendFormat": "pod: {{ pod_name }} | {{ container_name }}",
+            "legendFormat": "pod: {{ pod }} | {{ container }}",
             "metric": "container_memory_usage:sort_desc",
             "refId": "A",
             "step": 10
           },
           {
-            "expr": "sum (container_memory_working_set_bytes{image!=\"\",name!~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}) by (node, name, image)",
+            "expr": "sum (container_memory_working_set_bytes{image!=\"\",name!~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (node, name, image)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
@@ -1727,7 +1727,7 @@
             "step": 10
           },
           {
-            "expr": "sum (container_memory_working_set_bytes{rkt_container_name!=\"\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}) by (node, rkt_container_name)",
+            "expr": "sum (container_memory_working_set_bytes{rkt_container_name!=\"\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (node, rkt_container_name)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
@@ -1840,7 +1840,7 @@
         "steppedLine": true,
         "targets": [
           {
-            "expr": "sum (container_memory_working_set_bytes{id!=\"/\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}) by (id)",
+            "expr": "sum (container_memory_working_set_bytes{id!=\"/\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}) by (id)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
@@ -1953,21 +1953,21 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (pod_name)",
+            "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (pod)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
-            "legendFormat": "-> {{ pod_name }}",
+            "legendFormat": "-> {{ pod }}",
             "metric": "network",
             "refId": "A",
             "step": 10
           },
           {
-            "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (pod_name)",
+            "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (pod)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
-            "legendFormat": "<- {{ pod_name }}",
+            "legendFormat": "<- {{ pod }}",
             "metric": "network",
             "refId": "B",
             "step": 10
@@ -2076,29 +2076,29 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (container_name, pod_name)",
+            "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (container, pod)",
             "format": "time_series",
             "hide": false,
             "interval": "10s",
             "intervalFactor": 1,
-            "legendFormat": "-> pod: {{ pod_name }} | {{ container_name }}",
+            "legendFormat": "-> pod: {{ pod }} | {{ container }}",
             "metric": "network",
             "refId": "B",
             "step": 10
           },
           {
-            "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (container_name, pod_name)",
+            "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (container, pod)",
             "format": "time_series",
             "hide": false,
             "interval": "10s",
             "intervalFactor": 1,
-            "legendFormat": "<- pod: {{ pod_name }} | {{ container_name }}",
+            "legendFormat": "<- pod: {{ pod }} | {{ container }}",
             "metric": "network",
             "refId": "D",
             "step": 10
           },
           {
-            "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name!~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (node, name, image)",
+            "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name!~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (node, name, image)",
             "format": "time_series",
             "hide": false,
             "interval": "10s",
@@ -2109,7 +2109,7 @@
             "step": 10
           },
           {
-            "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name!~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (node, name, image)",
+            "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name!~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (node, name, image)",
             "format": "time_series",
             "hide": false,
             "interval": "10s",
@@ -2120,7 +2120,7 @@
             "step": 10
           },
           {
-            "expr": "sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (node, rkt_container_name)",
+            "expr": "sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (node, rkt_container_name)",
             "format": "time_series",
             "hide": false,
             "interval": "10s",
@@ -2131,7 +2131,7 @@
             "step": 10
           },
           {
-            "expr": "- sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (node, rkt_container_name)",
+            "expr": "- sum (rate (container_network_transmit_bytes_total{rkt_container_name!=\"\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (node, rkt_container_name)",
             "format": "time_series",
             "hide": false,
             "interval": "10s",
@@ -2245,7 +2245,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum (rate (container_network_receive_bytes_total{id!=\"/\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (id)",
+            "expr": "sum (rate (container_network_receive_bytes_total{id!=\"/\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (id)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
@@ -2255,7 +2255,7 @@
             "step": 10
           },
           {
-            "expr": "- sum (rate (container_network_transmit_bytes_total{id!=\"/\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\"}[1m])) by (id)",
+            "expr": "- sum (rate (container_network_transmit_bytes_total{id!=\"/\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\"}[1m])) by (id)",
             "format": "time_series",
             "interval": "10s",
             "intervalFactor": 1,
@@ -2391,14 +2391,14 @@
             "value": "$__all"
           },
           "datasource": "Prometheus",
-          "definition": "label_values(container_cpu_usage_seconds_total{node=~\"$Node\",namespace=~\"$namespace\", pod_name=~\".*$filter.*\"}, pod_name)",
+          "definition": "label_values(container_cpu_usage_seconds_total{node=~\"$Node\",namespace=~\"$namespace\", pod=~\".*$filter.*\"}, pod)",
           "hide": 0,
           "includeAll": true,
           "label": "Pod",
           "multi": true,
           "name": "pod",
           "options": [],
-          "query": "label_values(container_cpu_usage_seconds_total{node=~\"$Node\",namespace=~\"$namespace\", pod_name=~\".*$filter.*\"}, pod_name)",
+          "query": "label_values(container_cpu_usage_seconds_total{node=~\"$Node\",namespace=~\"$namespace\", pod=~\".*$filter.*\"}, pod)",
           "refresh": 1,
           "regex": "",
           "skipUrlSync": false,
@@ -2443,5 +2443,5 @@
     "timezone": "browser",
     "title": "Container Health",
     "uid": "mG-D07Nmh",
-    "version": 6
+    "version": 7
   }

--- a/kube-at-a-glance.json
+++ b/kube-at-a-glance.json
@@ -1007,7 +1007,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count (container_last_seen{container_name=\"POD\", node=~\"^$Node$\"}) / sum (kube_node_status_capacity_pods{node=~\"^$Node$\"}) * 100",
+          "expr": "count (container_last_seen{container=\"POD\", node=~\"^$Node$\"}) / sum (kube_node_status_capacity_pods{node=~\"^$Node$\"}) * 100",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -1463,7 +1463,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count (container_last_seen{container_name=\"POD\", node=~\"^$Node$\"})",
+          "expr": "count (container_last_seen{container=\"POD\", node=~\"^$Node$\"})",
           "format": "time_series",
           "instant": true,
           "interval": "10s",
@@ -1848,7 +1848,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count (container_last_seen{container_name=\"POD\", node=~\"^$Node$\"})",
+          "expr": "count (container_last_seen{container=\"POD\", node=~\"^$Node$\"})",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -2199,10 +2199,10 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\"}[1m])) by (pod_name)",
+              "expr": "sum (rate (container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\"}[1m])) by (pod)",
               "interval": "10s",
               "intervalFactor": 1,
-              "legendFormat": "{{ pod_name }}",
+              "legendFormat": "{{ pod }}",
               "metric": "container_cpu",
               "refId": "A",
               "step": 10
@@ -2316,10 +2316,10 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\"}) by (pod_name)",
+              "expr": "sum (container_memory_working_set_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\"}) by (pod)",
               "interval": "10s",
               "intervalFactor": 1,
-              "legendFormat": "{{ pod_name }}",
+              "legendFormat": "{{ pod }}",
               "metric": "container_memory_usage:sort_desc",
               "refId": "A",
               "step": 10
@@ -2433,19 +2433,19 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\"}[1m])) by (pod_name)",
+              "expr": "sum (rate (container_network_receive_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\"}[1m])) by (pod)",
               "interval": "10s",
               "intervalFactor": 1,
-              "legendFormat": "-> {{ pod_name }}",
+              "legendFormat": "-> {{ pod }}",
               "metric": "network",
               "refId": "A",
               "step": 10
             },
             {
-              "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\"}[1m])) by (pod_name)",
+              "expr": "- sum (rate (container_network_transmit_bytes_total{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\"}[1m])) by (pod)",
               "interval": "10s",
               "intervalFactor": 1,
-              "legendFormat": "<- {{ pod_name }}",
+              "legendFormat": "<- {{ pod }}",
               "metric": "network",
               "refId": "B",
               "step": 10
@@ -2621,5 +2621,5 @@
   "timezone": "browser",
   "title": "Kube at a Glance",
   "uid": "kube-at-a-glance",
-  "version": 1
+  "version": 2
 }

--- a/kube-ephemeral-storage.json
+++ b/kube-ephemeral-storage.json
@@ -603,12 +603,12 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum (container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod_name=~\"$pod\",pod_name=~\".*$filter.*\"}) by (pod_name)",
+          "expr": "sum (container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod)",
           "format": "time_series",
           "hide": false,
           "interval": "10s",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "metric": "container_cpu",
           "refId": "A",
           "step": 10
@@ -1118,14 +1118,14 @@
           ]
         },
         "datasource": "Prometheus",
-        "definition": "label_values(container_fs_usage_bytes{node=~\"$Node\",namespace=~\"$namespace\", pod_name=~\".*$filter.*\"}, pod_name)",
+        "definition": "label_values(container_fs_usage_bytes{node=~\"$Node\",namespace=~\"$namespace\", pod=~\".*$filter.*\"}, pod)",
         "hide": 0,
         "includeAll": true,
         "label": "Pod",
         "multi": true,
         "name": "pod",
         "options": [],
-        "query": "label_values(container_fs_usage_bytes{node=~\"$Node\",namespace=~\"$namespace\", pod_name=~\".*$filter.*\"}, pod_name)",
+        "query": "label_values(container_fs_usage_bytes{node=~\"$Node\",namespace=~\"$namespace\", pod=~\".*$filter.*\"}, pod)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1170,5 +1170,5 @@
   "timezone": "browser",
   "title": "Ephemeral Storage",
   "uid": "aeCh9Kie5o",
-  "version": 9
+  "version": 10
 }

--- a/kube-quotas-cluster.json
+++ b/kube-quotas-cluster.json
@@ -141,7 +141,7 @@
             "refId": "F"
           },
           {
-            "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", container_name!=\"POD\"}\n)",
+            "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", container!=\"POD\"}\n)",
             "format": "time_series",
             "interval": "1m",
             "intervalFactor": 1,
@@ -309,7 +309,7 @@
             "refId": "E"
           },
           {
-            "expr": "sum(\n  rate(\n    container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", container_name!=\"POD\"}[1m]\n  )\n)",
+            "expr": "sum(\n  rate(\n    container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", container!=\"POD\"}[1m]\n  )\n)",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -490,5 +490,5 @@
     "timezone": "",
     "title": "Kube Quotas (Cluster)",
     "uid": "XN5am50Zz",
-    "version": 16
+    "version": 17
 }

--- a/kube-quotas-namespace.json
+++ b/kube-quotas-namespace.json
@@ -565,7 +565,7 @@
           "refId": "F"
         },
         {
-          "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", container_name!=\"POD\", pod_name=~\"$pod\"}\n)",
+          "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", container!=\"POD\", pod=~\"$pod\"}\n)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -2282,5 +2282,5 @@
   "timezone": "",
   "title": "Kube Quotas (Namespace)",
   "uid": "6MFyi50Zzw3",
-  "version": 8
+  "version": 9
 }

--- a/pod-resource-usage.json
+++ b/pod-resource-usage.json
@@ -15,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1575047616528,
+  "id": 6,
+  "iteration": 1591121024502,
   "links": [],
   "panels": [
     {
@@ -424,7 +425,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\"}\n)",
+          "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -506,7 +507,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(\n  container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\"}\n)\n/\nsum(\n  kube_pod_container_resource_limits_memory_bytes{namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}\n)",
+          "expr": "sum(\n  container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}\n)\n/\nsum(\n  kube_pod_container_resource_limits_memory_bytes{namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -588,7 +589,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(\n  rate(\n      container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\"}[1m]\n  )\n)",
+          "expr": "sum(\n  rate(\n      container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}[1m]\n  )\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -670,7 +671,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(\n  rate(\n      container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\"}[1m]\n  )\n)\n/\nsum(\n  kube_pod_container_resource_limits_cpu_cores{namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}\n)",
+          "expr": "sum(\n  rate(\n      container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}[1m]\n  )\n)\n/\nsum(\n  kube_pod_container_resource_limits_cpu_cores{namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -751,7 +752,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(\n  sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\"}\n  ) by (pod_name),\n  \"pod\", \n  \"$1\",\n  \"pod_name\",\n  \"(.*)\"\n)\n/ on (pod)\nsum(\n  kube_pod_container_resource_limits_memory_bytes{}\n) by (pod)",
+          "expr": "  sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}\n  ) by (pod)\n/ on (pod)\nsum(\n  kube_pod_container_resource_limits_memory_bytes{}\n) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -854,7 +855,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(\n  sum(\n    rate(\n      container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\"}[1m]\n    )\n  ) by (pod_name),\n  \"pod\", \n  \"$1\",\n  \"pod_name\",\n  \"(.*)\"\n)\n/ on (pod)\nsum(\n  kube_pod_container_resource_limits_cpu_cores{}\n) by (pod)",
+          "expr": "  sum(\n    rate(\n      container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}[1m]\n    )\n  ) by (pod)\n/ on (pod)\nsum(\n  kube_pod_container_resource_limits_cpu_cores{}\n) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -954,7 +955,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(\n  sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\", container_name!=\"POD\"}\n  ) by (pod_name),\n  \"pod\", \n  \"$1\",\n  \"pod_name\",\n  \"(.*)\"\n)",
+          "expr": "\n  sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\", container!=\"POD\"}\n  ) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1056,11 +1057,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  rate(\n    container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\"}[1m]\n  )\n) by (pod_name)",
+          "expr": "sum(\n  rate(\n    container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}[1m]\n  )\n) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{  pod_name }}",
+          "legendFormat": "{{  pod }}",
           "refId": "A",
           "step": 20
         }
@@ -1160,12 +1161,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(\n  sum(\n    rate(\n      container_memory_failcnt{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\", container_name!=\"POD\"}[1m]\n    )\n  ) by (pod_name),\n  \"pod\", \n  \"$1\",\n  \"pod_name\",\n  \"(.*)\"\n)",
+          "expr": "\n  sum(\n    rate(\n      container_memory_failcnt{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\", container!=\"POD\"}[1m]\n    )\n  ) by (pod)",
           "format": "time_series",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "metric": "container_memory_usage_bytes",
           "refId": "A",
           "step": 10
@@ -1263,11 +1264,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(\n  sum(\n    rate(\n      container_cpu_cfs_throttled_seconds_total{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\", container_name!=\"POD\"}[1m]\n    )\n  ) by (pod_name),\n  \"pod\", \n  \"$1\",\n  \"pod_name\",\n  \"(.*)\"\n)",
+          "expr": "\n  sum(\n    rate(\n      container_cpu_cfs_throttled_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\", container!=\"POD\"}[1m]\n    )\n  ) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A",
           "step": 20
         }
@@ -1364,11 +1365,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",namespace=~\"$namespace\",pod_name=~\"$pod\",pod_name=~\".*$filter.*\"}) by (pod_name)",
+          "expr": "sum (container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A",
           "step": 20
         }
@@ -1493,7 +1494,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\", container_name!=\"POD\"}\n) by (instance)",
+          "expr": "sum(\n    container_memory_working_set_bytes{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\", container!=\"POD\"}\n) by (instance)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1593,7 +1594,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n    rate(\n        container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\"}[1m]\n    )\n) by (instance)",
+          "expr": "sum(\n    rate(\n        container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}[1m]\n    )\n) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{  instance }}",
@@ -1696,7 +1697,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  rate(\n    container_memory_failcnt{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\", container_name!=\"POD\"}[1m]\n  )\n) by (instance)",
+          "expr": "sum(\n  rate(\n    container_memory_failcnt{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\", container!=\"POD\"}[1m]\n  )\n) by (instance)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1799,7 +1800,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  rate(\n    container_cpu_cfs_throttled_seconds_total{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\", pod_name=~\"$pod\", container_name!=\"POD\"}[1m]\n  )\n) by (instance)",
+          "expr": "sum(\n  rate(\n    container_cpu_cfs_throttled_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\", container!=\"POD\"}[1m]\n  )\n) by (instance)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
@@ -1899,7 +1900,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(\n  container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",namespace=~\"$namespace\",pod_name=~\"$pod\",pod_name=~\".*$filter.*\"}\n) by (instance)",
+          "expr": "sum(\n  container_fs_usage_bytes{image!=\"\",name=~\"^k8s_.*\",namespace=~\"$namespace\",pod=~\"$pod\",pod=~\".*$filter.*\"}\n) by (instance)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
@@ -1961,7 +1962,6 @@
       {
         "allValue": ".+",
         "current": {
-          "tags": [],
           "text": "monitoring",
           "value": [
             "monitoring"
@@ -2011,14 +2011,14 @@
           "value": "$__all"
         },
         "datasource": "Prometheus",
-        "definition": "label_values(container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\"}, pod_name)",
+        "definition": "label_values(container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\"}, pod)",
         "hide": 0,
         "includeAll": true,
         "label": "Pod",
         "multi": true,
         "name": "pod",
         "options": [],
-        "query": "label_values(container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod_name=~\".*$filter.*\"}, pod_name)",
+        "query": "label_values(container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\"}, pod)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -2063,5 +2063,5 @@
   "timezone": "browser",
   "title": "Pod Resource Usage",
   "uid": "hYTBQhQiz",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
If I'm not mistaken those metrics had 2 labels for pod, `pod_name` and `pod`, I guess they removed the `pod_name`. 

This PR replace `pod_name` for `pod` and `container_ name` for `container`.

It affects the following dashboards:
* Kube quotas (Cluster)
* Kube quotas (Namespace)
* Pod resource usage
* Container health
* Kube at a glance
* Kube ephemeral storage