### PR TITLE
Add cpu throttled periods percentage to pod resource usage dashboard

### DIFF
--- a/pod-resource-usage.json
+++ b/pod-resource-usage.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": 7,
-  "iteration": 1615912976023,
+  "iteration": 1615913857722,
   "links": [],
   "panels": [
     {
@@ -1421,6 +1421,7 @@
         "x": 0,
         "y": 28
       },
+      "hiddenSeries": false,
       "id": 30,
       "legend": {
         "alignAsTable": true,
@@ -1505,6 +1506,114 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "Percentage of the CPU scheduler periods that the given pods were CPU throttled.\n\nThis graph is useful to detect situations where CPU is being limited during small bursts of activity, which could be causing slow application responses, but the sampling rate is unable to spot those short periods.",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "hiddenSeries": false,
+      "id": 33,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(\n  (\n    rate(\n      container_cpu_cfs_throttled_periods_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\", container!=\"POD\"}[2m]\n    ) / rate(\n      container_cpu_cfs_periods_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\", container!=\"POD\"}[2m]\n    )\n    * 100\n  )\n) by (pod)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ pod }}",
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU Throttling",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "% of periods throttled",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
@@ -1563,6 +1672,7 @@
         "x": 0,
         "y": 38
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "alignAsTable": true,
@@ -1669,6 +1779,7 @@
         "x": 12,
         "y": 38
       },
+      "hiddenSeries": false,
       "id": 11,
       "legend": {
         "alignAsTable": true,
@@ -1774,6 +1885,7 @@
         "x": 0,
         "y": 45
       },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
         "alignAsTable": true,
@@ -1885,6 +1997,7 @@
         "x": 12,
         "y": 45
       },
+      "hiddenSeries": false,
       "id": 7,
       "legend": {
         "alignAsTable": true,

--- a/pod-resource-usage.json
+++ b/pod-resource-usage.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 6,
-  "iteration": 1591121024502,
+  "id": 7,
+  "iteration": 1615912976023,
   "links": [],
   "panels": [
     {
@@ -44,6 +44,12 @@
       ],
       "datasource": null,
       "description": "Minimum memory that nodes are expected to have free for the given pods to be allocated there on aggregate.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "bytes",
       "gauge": {
         "maxValue": 100,
@@ -75,7 +81,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -126,6 +131,12 @@
       ],
       "datasource": null,
       "description": "Maximum memory that the given pods are allowed to consume on aggregate.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "bytes",
       "gauge": {
         "maxValue": 100,
@@ -157,7 +168,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -209,6 +219,12 @@
       "datasource": null,
       "decimals": null,
       "description": "Aggregate of minimum CPU core time that the nodes must have free for the given pods to be scheduled on those machines.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -240,7 +256,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": " vCPUs",
       "postfixFontSize": "30%",
       "prefix": "",
@@ -292,6 +307,12 @@
       "datasource": null,
       "decimals": null,
       "description": "Aggregate of maximum CPU time that the given pods are allowed to consume.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -323,7 +344,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": " vCPUs",
       "postfixFontSize": "30%",
       "prefix": "",
@@ -373,6 +393,12 @@
         "#d44a3a"
       ],
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "bytes",
       "gauge": {
         "maxValue": 100,
@@ -404,7 +430,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -455,6 +480,12 @@
       ],
       "datasource": null,
       "decimals": 1,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,
@@ -486,7 +517,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -537,6 +567,12 @@
       ],
       "datasource": null,
       "decimals": 2,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -568,7 +604,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": " vCPUs",
       "postfixFontSize": "30%",
       "prefix": "",
@@ -619,6 +654,12 @@
       ],
       "datasource": null,
       "decimals": 1,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,
@@ -650,7 +691,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -713,6 +753,12 @@
       "description": "Memory working set bytes over memory usage limit. Brief spikes over 100% are expected due to sampling noise and kernel allocation heuristics.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -722,6 +768,7 @@
         "x": 0,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "alignAsTable": true,
@@ -814,6 +861,12 @@
       "description": "CPU time use over CPU limit. Brief spikes over 100% are expected due to sampling noise and kernel scheduling heuristics.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -823,6 +876,7 @@
         "x": 12,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 13,
       "legend": {
         "alignAsTable": true,
@@ -916,6 +970,12 @@
       "description": "Aggregate memory consumed (measured by Working Set Size) by the given pods.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -925,6 +985,7 @@
         "x": 0,
         "y": 14
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "alignAsTable": true,
@@ -1016,6 +1077,12 @@
       "description": "Aggregate of CPU cores utilized by the given pods.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1025,6 +1092,7 @@
         "x": 12,
         "y": 14
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "alignAsTable": true,
@@ -1118,6 +1186,12 @@
       "description": "Count of memory allocation denials (aka failed malloc()s) over time for the given pods due to memory size limits.\n\nA non-zero number of denials does not necessarily mean that the application is being OOM-killed, but it is severely correlated to it when that application  memory quota is undersized.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1127,6 +1201,7 @@
         "x": 0,
         "y": 21
       },
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
         "alignAsTable": true,
@@ -1223,6 +1298,12 @@
       "description": "Sum of CPU cores that the given pods asked to be scheduled on for execution but were denied by usage limits.\n\nThis graph is useful to detect situations where CPU is being limited during small bursts of activity, which could be causing slow application responses, but the sampling rate is unable to spot those short periods.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1232,6 +1313,7 @@
         "x": 12,
         "y": 21
       },
+      "hiddenSeries": false,
       "id": 5,
       "legend": {
         "alignAsTable": true,
@@ -1324,6 +1406,12 @@
       "description": "Ephemeral storage usage per pod.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1433,6 +1521,12 @@
     {
       "content": "All metrics below sum the data only from the pods filtered above.",
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 2,
         "w": 24,
@@ -1442,7 +1536,6 @@
       "id": 9,
       "links": [],
       "mode": "markdown",
-      "options": {},
       "title": "Notice",
       "type": "text"
     },
@@ -1455,6 +1548,12 @@
       "description": "Sum of all the memory used (Working Set Size) by the given pods for each node on the cluster.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1555,6 +1654,12 @@
       "description": "Aggregate of CPU cores utilized by the given pods on each node.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1654,6 +1759,12 @@
       "description": "Count of memory allocation denials (aka failed malloc()s) over time for the given pods due to memory size limits on each node.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1759,6 +1870,12 @@
       "description": "Sum of CPU cores that the given pods asked to be scheduled for execution on but were denied by usage limits on each node.\n\nThis graph is useful to detect overcrowded nodes.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1859,6 +1976,12 @@
       "description": "Sum of ephemeral storage usage by the given pods on each node.\n",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
@@ -1952,7 +2075,7 @@
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 20,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "prod"
@@ -1961,6 +2084,7 @@
     "list": [
       {
         "current": {
+          "selected": false,
           "text": "prometheus-app-alpha-gm",
           "value": "prometheus-app-alpha-gm"
         },
@@ -1979,6 +2103,7 @@
       {
         "allValue": ".+",
         "current": {
+          "selected": true,
           "text": "monitoring",
           "value": [
             "monitoring"
@@ -2024,8 +2149,11 @@
       {
         "allValue": ".+",
         "current": {
+          "selected": true,
           "text": "All",
-          "value": "$__all"
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "$datasource",
         "definition": "label_values(container_cpu_usage_seconds_total{image!=\"\", namespace=~\"$namespace\", pod=~\".*$filter.*\"}, pod)",
@@ -2054,7 +2182,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",
@@ -2080,5 +2207,5 @@
   "timezone": "browser",
   "title": "Pod Resource Usage",
   "uid": "hYTBQhQiz",
-  "version": 2
+  "version": 1
 }


### PR DESCRIPTION
This adds a panel to the Pod Resource Utilization dashboard which
illustrates the percentage of CFS (scheduler) intervals for a given time
period in which the pod(s) experienced CPU throttling.


![Screen Shot 2021-03-16 at 3 24 58 PM](https://user-images.githubusercontent.com/59154/111368150-dfd78c00-866b-11eb-83cc-27c611737dec.png)
