### PR TITLE
Adding Pod Rediness Dash

### DIFF
--- a/pod-resource-usage.json
+++ b/pod-resource-usage.json
@@ -1437,6 +1437,94 @@
       }
     },
     {
+      "id": 34,
+      "gridPos": {
+        "x": 12,
+        "y": 31,
+        "w": 12,
+        "h": 8
+      },
+      "type": "timeseries",
+      "title": "Pod Rediness",
+      "datasource": "$datasource",
+      "targets": [
+        {
+          "refId": "A",
+          "editorMode": "code",
+          "expr": "sum(kube_pod_container_status_ready{namespace=\"$namespace\", pod=~\".*$filter.*\", pod=~\"$pod\"}) by (pod)",
+          "legendFormat": "{{ pod }}",
+          "range": true,
+          "format": "time_series",
+          "exemplar": false
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 80,
+                "color": "red"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "description": "Pod rediness"
+    },
+    {
       "collapsed": true,
       "datasource": null,
       "gridPos": {


### PR DESCRIPTION
This PR incorporates a pod readiness dashboard into the current pod resource usage dashboard. By doing so, @powerhome/forever-people aims to enhance the monitoring of pod health and status, while also providing the capability to analyze historical data.


![Screenshot 2024-04-05 at 1 15 57 PM](https://github.com/powerhome/APP-Grafana-Dashboards/assets/1783035/7177a7f4-c8b9-4573-83a3-8f40673c138f)

