### PR TITLE
[FVR-190] Puma - Add request queue depth

### DIFF
--- a/puma.json
+++ b/puma.json
@@ -68,7 +68,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "puma_backlog{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}",
+          "expr": "puma_queued_requests{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}",
           "interval": "",
           "legendFormat": "{{ pod }}",
           "refId": "A"
@@ -165,7 +165,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "puma_pool_capacity{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}",
+          "expr": "sum by (pod)(puma_pool_capacity{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"})",
           "interval": "",
           "legendFormat": "{{ pod }}",
           "refId": "A"
@@ -279,7 +279,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[1m])",
+          "expr": "sum by (pod) (increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ pod }}",
@@ -368,7 +368,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[$__range])",
+          "expr": "sum by (pod)(increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[$__range]))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ pod }}",


### PR DESCRIPTION
Closes: https://nitro.powerhrg.com/runway/backlog_items/FVR-190
Depends on: https://github.com/powerhome/nitro-web/pull/39227

Chart the Puma pod's Request Queue depth over time.

We want to measure the number of connections waiting to be accepted by
the Puma process. Previously, we'd assumed that the `puma_backlog`
measure this. However, "backlog" measures the number of client
connections which have already been accepted, but are awaiting
assignment to a Puma worker. Empirically, this number is always 0.

https://github.com/powerhome/nitro-web/pull/39227 introduces a custom
measure to track the request queue and we'd like to plot it in the
Puma dashboard.

<img width="1378" alt="Screenshot 2024-04-24 at 12 07 57 PM" src="https://github.com/powerhome/APP-Grafana-Dashboards/assets/59154/b27d531a-232c-41c6-a9ed-802fe3f7f822">


It should also be noted that these changes work with the previously 
used puma-metrics exporter gem, however the request queue depth 
measure is NOT exported by this gem.

Example of the dashboard for QA (old exporter):

<img width="1378" alt="Screenshot 2024-04-24 at 12 47 27 PM" src="https://github.com/powerhome/APP-Grafana-Dashboards/assets/59154/b23d332b-d9ad-431a-97ec-4f6345d75902">


