### PR TITLE
Revert "[FVR-190] Puma - Add request queue depth"

### DIFF
--- a/puma.json
+++ b/puma.json
@@ -68,7 +68,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "puma_queued_requests{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}",
+          "expr": "puma_backlog{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}",
           "interval": "",
           "legendFormat": "{{ pod }}",
           "refId": "A"
@@ -165,7 +165,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (pod)(puma_pool_capacity{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"})",
+          "expr": "puma_pool_capacity{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}",
           "interval": "",
           "legendFormat": "{{ pod }}",
           "refId": "A"
@@ -279,7 +279,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (pod) (increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[1m]))",
+          "expr": "increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[1m])",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ pod }}",
@@ -368,7 +368,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "sum by (pod)(increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[$__range]))",
+          "expr": "increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[$__range])",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ pod }}",


### PR DESCRIPTION
Reverts powerhome/APP-Grafana-Dashboards#68

Part of: https://github.com/powerhome/nitro-web/pull/39489

This complexity was introduced into nitro-web to measure and chart Puma Request Queue depth. Originally we were trying to gather context on elevated 5xx HTTP responses when switching webservers to Puma in nitro-web-production. Observations in https://github.com/powerhome/nitro-web/pull/39394 illustrate that, in practice, this measure is not as interesting as I'd originally assumed.