### PR TITLE
Puma -- show pod-level metrics

### DIFF
--- a/puma.json
+++ b/puma.json
@@ -68,7 +68,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "puma_backlog{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}",
+          "expr": "sum by (pod)(puma_backlog{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"})",
           "interval": "",
           "legendFormat": "{{ pod }}",
           "refId": "A"
@@ -165,7 +165,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "puma_pool_capacity{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}",
+          "expr": "sum by (pod)(puma_pool_capacity{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"})",
           "interval": "",
           "legendFormat": "{{ pod }}",
           "refId": "A"
@@ -279,7 +279,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[1m])",
+          "expr": "sum by (pod)(increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ pod }}",
@@ -368,7 +368,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[$__range])",
+          "expr": "sum by (pod)(increase(puma_requests_count{namespace=~\"$namespace\",job=~\".*$job.*\",pod=~\".*$filter.*\",pod=~\"$pod\"}[$__range]))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ pod }}",


### PR DESCRIPTION
Measures are currently displayed for each Puma process. This makes 
it hard to see what's going on in a puma pod at a glance.

Current - 1 pod:

<img width="1840" alt="Screenshot 2024-05-03 at 3 25 10 PM" src="https://github.com/powerhome/APP-Grafana-Dashboards/assets/59154/e2b48165-08f8-4300-b803-faf3549e615b">


This change rolls measures up to the pod-level to provide the same
granularity of what we're used to in the Passenger dashboard.

Proposed -  1 pod:

<img width="1840" alt="Screenshot 2024-05-03 at 3 26 08 PM" src="https://github.com/powerhome/APP-Grafana-Dashboards/assets/59154/c41aa51c-2b30-4c5b-96b7-c306404b99bd">
