### PR TITLE
Filter sum of memory request to only pods that are running

### DIFF
--- a/app-resource-loss-simulator.json
+++ b/app-resource-loss-simulator.json
@@ -464,7 +464,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\",node=~\".*app-worker.*\"} and on (pod) kube_pod_status_phase{phase=~\"Running\"} == 1))",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\",node=~\".*app-worker.*\"} and on (pod) kube_pod_status_phase{phase=~\"Running\"} == 1)",
           "hide": false,
           "interval": "",
           "legendFormat": "sum of pods memory request on workers",

--- a/app-resource-loss-simulator.json
+++ b/app-resource-loss-simulator.json
@@ -464,7 +464,7 @@
             "uid": "${datasource}"
           },
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\",node=~\".*app-worker.*\"})",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\",node=~\".*app-worker.*\"} and on (pod) kube_pod_status_phase{phase=~\"Running\"} == 1))",
           "hide": false,
           "interval": "",
           "legendFormat": "sum of pods memory request on workers",


### PR DESCRIPTION
We added this filter to the CPU but for some reason we forgot about the memory. With this the value should exclude pods that are left in the namespace in a `Failed` or `Succeeded` state, normally the result of a Job, since those pods don't have containers running, they are there just to keep its metadata and logs until the job is deleted, they are not considered for quota or the kube scheduler.